### PR TITLE
Comments in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **Describe the bug**
 
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **Steps to reproduce**
 
@@ -19,17 +19,18 @@ A clear and concise description of what the bug is.
 
 **Expected behavior**
 
-Describe what did you expect to happen
+<!-- Describe what you expected to happen -->
 
 **Actual behavior**
 
-Describe what actually happened
+<!-- Describe what actually happened -->
 
 **Versions used**
 
-Add following information:
+<!-- Please add following information:
 
 - `dotnet --info` on the machine being used to build
 - `dotnet --info` on the machine where app is being run (not applicable for self-contained apps)
 - Version of `System.Device.Gpio` package
 - Version of `Iot.Device.Bindings` package (not needed if bug is in `System.Device.Gpio`)
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,12 +9,12 @@ assignees: ''
 
 **Is your feature request related to a problem? Please describe.**
 
-Describe what problem are you trying to solve or what's the expected outcome.
+<!-- Describe what problem are you trying to solve or what's the expected outcome.
 
 If you'd like us to add a new device binding please add a full name and ideally links to specification / pictures of device you'd like to see here.
 
-Please review [list of devices](https://github.com/dotnet/iot/blob/main/src/devices/README.md) to see if there is any similar device (perhaps belonging to the same family) which can be extended to also support your device.
+Please review [list of devices](https://github.com/dotnet/iot/blob/main/src/devices/README.md) to see if there is any similar device (perhaps belonging to the same family) which can be extended to also support your device. -->
 
 **Describe the ideal solution**
 
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
+<!--
 - If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
 - Describe what is the issue being fixed
 - If there is any follow-up work please create issues for that
 - If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
 - Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
+-->


### PR DESCRIPTION
Add XML comments around content so that it if someone forgets to delete it, doesn't show up in the issue or PR that's created. This is what dotnet/runtime does.

Eg., the text below doesn't show up:
<!--
* This will not show up
-->